### PR TITLE
fixed build with vcc

### DIFF
--- a/source/cpuwhat/private/info_x86.nim
+++ b/source/cpuwhat/private/info_x86.nim
@@ -3,7 +3,7 @@ import std / strutils
 proc cpuidX86(eaxi, ecxi :int32) :tuple[eax, ebx, ecx, edx :int32] =
   when defined(vcc):
     # limited inline asm support in vcc, so intrinsics, here we go:
-    proc cpuidVcc(cpuInfo :ptr int32; functionID :int32)
+    proc cpuidVcc(cpuInfo :ptr int32; functionID, subFunctionId: int32)
       {.cdecl, importc: "__cpuidex", header: "intrin.h".}
     cpuidVcc(addr result.eax, eaxi, ecxi)
   else:


### PR DESCRIPTION
The compilation with vcc is broken, as no subFunctionId was declared. Current output:
```
nim c -d:danger --cc:vcc teste
Hint: used config file 'D:\Nim\config\nim.cfg' [Conf]
Hint: used config file 'D:\Nim\config\config.nims' [Conf]
.................
C:\Users\Jose\.nimble\pkgs\cpuwhat-0.1.1\cpuwhat\private\info_x86.nim(8, 13) Error: type mismatch: got <ptr int32, int32, int32>
but expected one of:
proc cpuidVcc(cpuInfo: ptr int32; functionID: int32)
  first type mismatch at position: 3
  extra argument given

expression: cpuidVcc(addr result.eax, eaxi, ecxi)
```